### PR TITLE
Improve Sankey diagram

### DIFF
--- a/src/Sankey.js
+++ b/src/Sankey.js
@@ -139,10 +139,7 @@ export default class Sankey extends Viz {
     const links = this._links.map((link, i) => {
       const check = ["source", "target"];
       const linkLookup = check.reduce((result, item) => {
-        result[item] =
-          typeof link[item] === "number"
-            ? nodeLookup[link[item]]
-            : nodeLookup[link[item]];
+        result[item] = nodeLookup[link[item]];
         return result;
       }, {});
       return {

--- a/src/Sankey.js
+++ b/src/Sankey.js
@@ -113,7 +113,15 @@ export default class Sankey extends Viz {
     const height = this._height - this._margin.top - this._margin.bottom,
           width = this._width - this._margin.left - this._margin.right;
 
-    const nodes = this._nodes
+    const _nodes = Array.isArray(this._nodes)
+      ? this._nodes
+      : this._links.reduce((all, d) => {
+        if (!all.includes(d.source)) all.push(d.source);
+        if (!all.includes(d.target)) all.push(d.target);
+        return all;
+      }, []).map(id => ({id}));
+
+    const nodes = _nodes
       .map((n, i) => ({
         __d3plus__: true,
         data: n,

--- a/src/Sankey.js
+++ b/src/Sankey.js
@@ -40,6 +40,8 @@ export default class Sankey extends Viz {
     super();
     this._nodeId = accessor("id");
     this._links = accessor("links");
+    this._linksSource = "source";
+    this._linksTarget = "target";
     this._noDataMessage = false;
     this._nodes = accessor("nodes");
     this._nodeAlign = sankeyAligns.justify;
@@ -113,11 +115,12 @@ export default class Sankey extends Viz {
     const height = this._height - this._margin.top - this._margin.bottom,
           width = this._width - this._margin.left - this._margin.right;
 
+    console.log(this._links);
     const _nodes = Array.isArray(this._nodes)
       ? this._nodes
       : this._links.reduce((all, d) => {
-        if (!all.includes(d.source)) all.push(d.source);
-        if (!all.includes(d.target)) all.push(d.target);
+        if (!all.includes(d.source)) all.push(d[this._linksSource]);
+        if (!all.includes(d.target)) all.push(d[this._linksTarget]);
         return all;
       }, []).map(id => ({id}));
 
@@ -137,14 +140,14 @@ export default class Sankey extends Viz {
     }, {});
 
     const links = this._links.map((link, i) => {
-      const check = ["source", "target"];
+      const check = [this._linksSource, this._linksTarget];
       const linkLookup = check.reduce((result, item) => {
         result[item] = nodeLookup[link[item]];
         return result;
       }, {});
       return {
-        source: linkLookup.source,
-        target: linkLookup.target,
+        source: linkLookup[this._linksSource],
+        target: linkLookup[this._linksTarget],
         value: this._value(link, i)
       };
     });
@@ -238,6 +241,30 @@ The value passed should be an *Array* of data. An optional formatting function c
       return this;
     }
     return this._links;
+  }
+
+  /**
+      @memberof Sankey
+      @desc Sets the source's node name.
+      @param {Function|String} [*value* = "source"]
+      @chainable
+  */
+  linksSource(_) {
+    return arguments.length
+      ? (this._linksSource = typeof _ === "function" ? _ : accessor(_), this)
+      : this._linksSource;
+  }
+
+  /**
+      @memberof Sankey
+      @desc Sets the target's node name.
+      @param {Function|String} [*value* = "target"]
+      @chainable
+  */
+  linksTarget(_) {
+    return arguments.length
+      ? (this._linksTarget = typeof _ === "function" ? _ : accessor(_), this)
+      : this._linksTarget;
   }
 
   /**

--- a/src/Sankey.js
+++ b/src/Sankey.js
@@ -115,12 +115,11 @@ export default class Sankey extends Viz {
     const height = this._height - this._margin.top - this._margin.bottom,
           width = this._width - this._margin.left - this._margin.right;
 
-    console.log(this._links);
     const _nodes = Array.isArray(this._nodes)
       ? this._nodes
       : this._links.reduce((all, d) => {
-        if (!all.includes(d.source)) all.push(d[this._linksSource]);
-        if (!all.includes(d.target)) all.push(d[this._linksTarget]);
+        if (!all.includes(d[this._linksSource])) all.push(d[this._linksSource]);
+        if (!all.includes(d[this._linksTarget])) all.push(d[this._linksTarget]);
         return all;
       }, []).map(id => ({id}));
 
@@ -246,25 +245,21 @@ The value passed should be an *Array* of data. An optional formatting function c
   /**
       @memberof Sankey
       @desc Sets the source's node name.
-      @param {Function|String} [*value* = "source"]
+      @param {String} [*value* = "source"]
       @chainable
   */
   linksSource(_) {
-    return arguments.length
-      ? (this._linksSource = typeof _ === "function" ? _ : accessor(_), this)
-      : this._linksSource;
+    return arguments.length ? (this._linksSource = _, this) : this._linksSource;
   }
 
   /**
       @memberof Sankey
       @desc Sets the target's node name.
-      @param {Function|String} [*value* = "target"]
+      @param {String} [*value* = "target"]
       @chainable
   */
   linksTarget(_) {
-    return arguments.length
-      ? (this._linksTarget = typeof _ === "function" ? _ : accessor(_), this)
-      : this._linksTarget;
+    return arguments.length ? (this._linksTarget = _, this) : this._linksTarget;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
closes #57 

### Description
<!--- Describe your changes in detail -->
This PR try to solve:

- In the old version, you needed having in the data `source` and `target` keys, but in this new version, I included `.linksSource()` and `.linksTarget()` that allows to use a different object key for `source/target` nodes.
- If you don't define the `nodes`, the algorithm will guess your nodes using `this._links`.
- Minor optimization in the script.

```
new d3plus.Sankey()
      .links("https://api.datamexico.org/tesseract/data.jsonrecords?State=1%2C2%2C3%2C4%2C5&Year=2010%2C2011%2C2012%2C2013&cube=economy_fdi&drilldowns=Year%2CState&locale=en&measures=Count&parents=false&sparse=false", resp => resp.data)
      .linksSource("Year")
      .linksTarget("State")
      .value("Count")
      .render();
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have documented all new methods.
- [ ] I have written tests for all new methods/functionality.
- [ ] I have written examples for all new methods/functionality.

